### PR TITLE
resovle the conplict

### DIFF
--- a/Module/COMX_NB-IoT/COMX_NB-IoT.ino
+++ b/Module/COMX_NB-IoT/COMX_NB-IoT.ino
@@ -304,7 +304,7 @@ void setup()
 {
 	// put your setup code here, to run once:
 	M5.begin();
-	Serial.begin(115200);
+	//Serial.begin(115200); compl  //conflict with M5.begin() that include Serial init.
 	Serial2.begin(115200, SERIAL_8N1, 5, 13);
 	//Serial.printf("FUCK STC\n");
 


### PR DESCRIPTION
comment one line code that is Serial.begin(115200); in setup().  because this line conflict with M5.begin() that include Serial init. tested with M5stack fire and NB-IOT-CN